### PR TITLE
Implement Behavior Trait based on upstream PR

### DIFF
--- a/src/behavior.rs
+++ b/src/behavior.rs
@@ -1,0 +1,50 @@
+use crate::observer::Observer;
+
+pub trait Behavior: Observer {
+  /// Get the value contained currently in the behavior
+  ///
+  /// Example:
+  /// ```
+  /// use rxrust::prelude::*;
+  /// let mut behavior = SharedBehaviorSubject::new(0);
+  /// behavior.clone()
+  ///     .into_shared()
+  ///     .subscribe(|value| println!("{value}"));
+  /// behavior.next(7);
+  /// println!("{}", behavior.peek());
+  ///
+  /// // print log:
+  /// // 0
+  /// // 7
+  /// // 7
+  ///
+  /// ```
+  fn peek(&self) -> <Self as Observer>::Item;
+
+  /// Update the behavior's value based on its last one
+  ///
+  /// Example:
+  /// ```
+  /// use rxrust::prelude::*;
+  /// let mut behavior = SharedBehaviorSubject::new(0);
+  /// behavior.clone()
+  ///     .into_shared()
+  ///     .subscribe(|value| println!("{value}"));
+  /// for i in 0..3 {
+  ///     behavior.next_by(|value| value + 1);
+  /// }
+  ///
+  /// // print log:
+  /// // 0
+  /// // 1
+  /// // 2
+  ///
+  /// ```
+  fn next_by(
+    &mut self,
+    f: impl FnOnce(<Self as Observer>::Item) -> <Self as Observer>::Item,
+  ) {
+    let data = f(self.peek());
+    self.next(data);
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ extern crate bencher;
 #[cfg(test)]
 pub mod test_scheduler;
 
+pub mod behavior;
 pub mod impl_helper;
 pub mod observable;
 pub mod observer;
@@ -28,6 +29,7 @@ pub mod type_hint;
 
 pub mod prelude {
 
+  pub use crate::behavior::*;
   pub use crate::observable;
   pub use crate::observable::*;
   pub use crate::observer;

--- a/src/subject/behavior_subject.rs
+++ b/src/subject/behavior_subject.rs
@@ -121,6 +121,22 @@ impl<'a, Item: Clone, Err> LocalObservable<'a>
   }
 }
 
+impl<'a, Item: Clone + 'static, Err: Clone> Behavior
+  for LocalBehaviorSubject<'a, Item, Err>
+{
+  fn peek(&self) -> <Self as Observer>::Item {
+    self.value.rc_deref().clone()
+  }
+}
+
+impl<Item: Clone + 'static, Err: Clone> Behavior
+  for SharedBehaviorSubject<Item, Err>
+{
+  fn peek(&self) -> <Self as Observer>::Item {
+    self.value.rc_deref().clone()
+  }
+}
+
 #[cfg(test)]
 mod test {
   use crate::prelude::*;


### PR DESCRIPTION
This PR introduces the `Behavior` trait to our version of `rxrust`. The trait allows contents of the implementor to be peekable using its own reference pointer.

The implementation is based on an [earlier draft of the pull request](https://github.com/rxRust/rxRust/pull/214/commits/e9f0775cc3b9aeddad05cfac71203d91acf6b485) in the main `rxrust` repository before its trait refactor. I'd like to suggest integrating this version, as our project relies on a version of rxrust that does not yet include the Behavior trait.

By merging this PR, we will be able to utilize the peekable behavior in our application.

Reference:
- Original PR: [behavior trait #214](https://github.com/rxRust/rxRust/pull/214)